### PR TITLE
janus-gateway.service: restart always instead of on-abnormal

### DIFF
--- a/janus-gateway.service
+++ b/janus-gateway.service
@@ -6,7 +6,7 @@ Wants=systemd-modules-load.service
 [Service]
 Type=simple
 ExecStart=/opt/janus/bin/janus -o
-Restart=on-abnormal
+Restart=always
 LimitNOFILE=65536
 RestartSec=4
 StandardOutput=null


### PR DESCRIPTION
NethServer/dev#5426