### PR TITLE
Revert ".spec: add systemd reload"

### DIFF
--- a/janus-gateway.spec
+++ b/janus-gateway.spec
@@ -6,8 +6,6 @@ Group: Network
 License: GPLv2
 Source0: https://github.com/meetecho/janus-gateway/archive/v0.2.5.tar.gz
 Source1: janus-gateway.service
-%{?systemd_requires}
-BuildRequires: systemd
 BuildRequires: libmicrohttpd-devel, jansson-devel, openssl-devel, libsrtp15-devel, glib-devel, opus-devel, libogg-devel, libcurl-devel, pkgconfig, gengetopt, libtool, autoconf, automake, libwebsockets-devel, doxygen, graphviz
 BuildRequires: sofia-sip
 BuildRequires: libnice-devel >= 0.1.4
@@ -30,9 +28,6 @@ DESTDIR=%buildroot make install
 DESTDIR=%buildroot make configs
 mkdir -p  %{buildroot}%{_unitdir}
 install -D -p -m 0644 %{SOURCE1} %{buildroot}%{_unitdir}/janus-gateway.service
-
-%post
-%systemd_post janus-gateway.service
 
 %clean
 rm -rf %{buildroot}


### PR DESCRIPTION
Reverts NethServer/janus-gateway#4
NethServer/dev#5426
The problem here is that [this](https://github.com/NethServer/janus-gateway/blob/79478cb9832785c1fb3c43fda8ccb3621c85af5c/janus-gateway.spec#L35)  doesn't do the daemon reload: see [this](https://github.com/systemd/systemd/blob/07a35e846b7986d3c02eca99fa291f6869035c58/src/core/macros.systemd.in#L51..L56)